### PR TITLE
rename matchEntries -> clearRules

### DIFF
--- a/__tests__/clearfolder.spec.ts
+++ b/__tests__/clearfolder.spec.ts
@@ -7,7 +7,7 @@ import {
   DEL,
   KEEP,
   m,
-  MatchEntry,
+  ClearRule,
 } from '../src'
 
 describe('[utils] clearFolder should...', () => {
@@ -47,7 +47,7 @@ describe('[utils] clearFolder should...', () => {
         'toDel',
       ),
     ]
-    const matchEntries: MatchEntry[] = [
+    const matchEntries: ClearRule[] = [
       KEEP(m.folder('toKeep')),
       DEL(m.folder('toDelWithKeep'), [
         KEEP(m.folder('toKeep')),

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Usage:
 
 ```typescript
 
-const matchEntries: MatchEntry[] = [
+const clearRules: ClearRule[] = [
   KEEP(m.folder('toKeep')),
   DEL(m.folder('toDelWithKeep'), [
     KEEP(m.folder('toKeep')),
@@ -17,7 +17,7 @@ const matchEntries: MatchEntry[] = [
 ]
 await clearFs({
   fullPath: fixturePath,
-  matchEntries,
+  clearRules,
   action: ACTIONS.DELETE,
 })
 ```


### PR DESCRIPTION
closes #3 
(confusing names)